### PR TITLE
Add the new fastLZWithUpperBoundEstimator

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 		repeatedByte1Estimator,
 		repeatedByte2Estimator,
 		repeatedOrZeroEstimator,
+		fastLZWithUpperBoundEstimator,
 		fastLZEstimator,
 		zlibBestEstimator,
 		zlibBestBatchEstimator, // final estimator value is always used as the "ground truth" against which others are measured
@@ -468,6 +469,14 @@ func zlibBestEstimator(tx []byte) float64 {
 
 func fastLZEstimator(tx []byte) float64 {
 	return float64(flzCompressLen(tx))
+}
+
+func fastLZWithUpperBoundEstimator(tx []byte) float64 {
+	fastLZSize := fastLZEstimator(tx) 
+	if fastLZSize > float64(len(tx)) {
+		return float64(len(tx))
+	}
+	return fastLZSize
 }
 
 // uncompressedSizeEstimator just returns the length of the input


### PR DESCRIPTION
Add a new fastLZWithUpperBoundEstimator. The 1m dataset running result (below) shows that there is no clear improvement for fastLZ with upper-bound.
```
Regression zlibBestBatchEstimator: 0.0008 + 1.0000*x_0 + -0.0000*x_1

========= TRAINING SET STATS: SCALAR MODEL, 1D REGRESSION, 2D REGRESSION ==========

 mean-absolute-error     uncompressedSizeEstimator     60.54     56.05     56.04
 mean-absolute-error               cheap0Estimator     54.19     57.51     61.07
 mean-absolute-error               cheap1Estimator     52.91     56.09     61.07
 mean-absolute-error               cheap2Estimator     52.63     55.17     61.07
 mean-absolute-error               cheap3Estimator     52.86     54.64     61.07
 mean-absolute-error               cheap4Estimator     53.38     54.41     61.07
 mean-absolute-error               cheap5Estimator     54.01     54.33     61.07
 mean-absolute-error        repeatedByte0Estimator     52.71     56.37     61.30
 mean-absolute-error        repeatedByte1Estimator     51.93     55.24     61.30
 mean-absolute-error        repeatedByte2Estimator     51.94     54.53     61.30
 mean-absolute-error       repeatedOrZeroEstimator     54.08     57.68     61.35
 mean-absolute-error               fastLZEstimator     38.19     38.49     37.45
 mean-absolute-error fastLZWithUpperBoundEstimator     38.00     38.30     37.23
 mean-absolute-error             zlibBestEstimator     41.07     37.02     37.14
 mean-absolute-error        zlibBestBatchEstimator      0.00      0.02      0.00

 root-mean-sq-error      uncompressedSizeEstimator    228.59    187.21    187.21
 root-mean-sq-error                cheap0Estimator    191.63    168.55    167.51
 root-mean-sq-error                cheap1Estimator    193.38    169.86    167.51
 root-mean-sq-error                cheap2Estimator    195.76    171.39    167.51
 root-mean-sq-error                cheap3Estimator    198.45    172.98    167.51
 root-mean-sq-error                cheap4Estimator    201.27    174.55    167.51
 root-mean-sq-error                cheap5Estimator    204.11    176.06    167.51
 root-mean-sq-error         repeatedByte0Estimator    189.53    166.88    164.62
 root-mean-sq-error         repeatedByte1Estimator    191.88    168.57    164.62
 root-mean-sq-error         repeatedByte2Estimator    194.66    170.36    164.62
 root-mean-sq-error        repeatedOrZeroEstimator    191.44    167.98    166.89
 root-mean-sq-error                fastLZEstimator     88.79     61.29     52.25
 root-mean-sq-error  fastLZWithUpperBoundEstimator     88.31     61.28     52.17
 root-mean-sq-error              zlibBestEstimator     92.78     45.82     45.77
 root-mean-sq-error         zlibBestBatchEstimator      0.00      0.04      0.01

========= SCALAR MODEL, 1D REGRESSION, 2D REGRESSION ==========

 mean-absolute-error     uncompressedSizeEstimator     54.94     55.07     55.06
 mean-absolute-error               cheap0Estimator     51.73     56.76     60.22
 mean-absolute-error               cheap1Estimator     50.45     55.40     60.22
 mean-absolute-error               cheap2Estimator     49.94     54.52     60.22
 mean-absolute-error               cheap3Estimator     49.92     53.99     60.22
 mean-absolute-error               cheap4Estimator     50.14     53.73     60.22
 mean-absolute-error               cheap5Estimator     50.52     53.64     60.22
 mean-absolute-error        repeatedByte0Estimator     50.35     55.65     60.42
 mean-absolute-error        repeatedByte1Estimator     49.45     54.57     60.42
 mean-absolute-error        repeatedByte2Estimator     49.24     53.89     60.41
 mean-absolute-error       repeatedOrZeroEstimator     51.66     56.96     60.53
 mean-absolute-error               fastLZEstimator     38.87     37.78     37.39
 mean-absolute-error fastLZWithUpperBoundEstimator     38.64     37.52     37.11
 mean-absolute-error             zlibBestEstimator     42.26     37.33     37.45
 mean-absolute-error        zlibBestBatchEstimator      0.00      0.01      0.00

 root-mean-sq-error      uncompressedSizeEstimator    259.37    220.14    220.14
 root-mean-sq-error                cheap0Estimator    208.11    190.61    187.88
 root-mean-sq-error                cheap1Estimator    211.19    193.09    187.88
 root-mean-sq-error                cheap2Estimator    214.89    195.75    187.88
 root-mean-sq-error                cheap3Estimator    218.87    198.41    187.88
 root-mean-sq-error                cheap4Estimator    222.90    200.97    187.88
 root-mean-sq-error                cheap5Estimator    226.87    203.37    187.88
 root-mean-sq-error         repeatedByte0Estimator    205.89    188.50    183.30
 root-mean-sq-error         repeatedByte1Estimator    209.70    191.50    183.30
 root-mean-sq-error         repeatedByte2Estimator    213.89    194.52    183.30
 root-mean-sq-error        repeatedOrZeroEstimator    207.51    189.66    186.66
 root-mean-sq-error                fastLZEstimator    101.33     59.97     51.02
 root-mean-sq-error  fastLZWithUpperBoundEstimator    100.81     60.04     50.99
 root-mean-sq-error              zlibBestEstimator    108.32     45.55     45.50
 root-mean-sq-error         zlibBestBatchEstimator      0.00      0.04      0.01
```