### PR TITLE
[Chore] Add minimum length check for fastlz input

### DIFF
--- a/main.go
+++ b/main.go
@@ -680,6 +680,9 @@ func flzCompressLen(ib []byte) uint32 {
 	}
 	a := uint32(0)
 	ipLimit := uint32(len(ib)) - 13
+	if len(ib) < 13 {
+		ipLimit = 0
+	}
 	for ip := a + 2; ip < ipLimit; {
 		r := uint32(0)
 		d := uint32(0)


### PR DESCRIPTION
Add minimum length check to be consistent with Michael's implementation: https://github.com/base-org/op-geth/blob/flz-l1-cost-func/core/types/rollup_cost.go#L394-L396